### PR TITLE
Use lodash instead of underscore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 intercept-stdout captures stdout
 
+Based on [this](https://gist.github.com/benbuckman/2758563) gist.
+
 ## Usage
 
 	var intercept = require("intercept-stdout"),
@@ -10,15 +12,15 @@ intercept-stdout captures stdout
 	var unhook_intercept = intercept(function(txt) {
 		captured_text += txt;
 	});
-	
+
 	console.log("This text is being captured");
-	
+
 	// Let's stop capturing stdout.
 	unhook_intercept();
-	
+
 	console.log("This text is not being captured");
-	
+
 ## Test
 
-	npm install mocha -g
-	mocha
+	npm install
+	npm test

--- a/intercept-stdout.js
+++ b/intercept-stdout.js
@@ -2,21 +2,21 @@
 // https://gist.github.com/benbuckman/2758563
 
 
-var _ 		= require('underscore'),
-	util 	= require('util');
+var toArray	= require('lodash.toarray'),
+	util			= require('util');
 
 // intercept stdout, passes thru callback
 // also pass console.error thru stdout so it goes to callback too
 // (stdout.write and stderr.write are both refs to the same stream.write function)
 // returns an unhook() function, call when done intercepting
 module.exports = function (callback) {
-	
+
 	var old_stdout_write = process.stdout.write,
 	old_console_error = console.error;
 
 	process.stdout.write = (function(write) {
 		return function(string, encoding, fd) {
-			var args = _.toArray(arguments);
+			var args = toArray(arguments);
 			write.apply(process.stdout, args);
 
 			// only intercept the string
@@ -26,7 +26,7 @@ module.exports = function (callback) {
 
 	console.error = (function(log) {
 		return function() {
-			var args = _.toArray(arguments);
+			var args = toArray(arguments);
 			args.unshift('[ERROR]');
 			console.log.apply(console.log, args);
 
@@ -40,5 +40,5 @@ module.exports = function (callback) {
 		process.stdout.write = old_stdout_write;
 		console.error = old_console_error;
 	};
-	
+
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/sfarthin/intercept-stdout/issues"
   },
   "dependencies": {
-    "underscore": "~1.5.2"
+    "lodash.toarray": "^3.0.0"
   },
   "devDependencies": {
     "chai": "~1.8.1",


### PR DESCRIPTION
Hey!

This is just a quick change from underscore to lodash. This basically just makes the module smaller.

If there's a goal in itself to mirror the original gist, then just close this :smile: 
