### PR TITLE
Add Typescript declaration file and udpate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ unhook_intercept();
 console.log("Logs:", logs);
 ```
 
+## Typescript
+
+A declaration file is provided. Use Typescript's [import = require() syntax](
+https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require):
+```typescript
+import intercept = require("intercept-stdout");
+```
+
 ## Test
 ```
 npm install

--- a/intercept-stdout.d.ts
+++ b/intercept-stdout.d.ts
@@ -1,0 +1,11 @@
+declare module 'intercept-stdout' {
+	type hookFunction = (txt: string) => string | void;
+	type unhookFunction = () => void;
+
+	function intercept(
+		stdoutIntercept: hookFunction,
+		stderrIntercept?: hookFunction,
+	): unhookFunction;
+
+	export = intercept;
+}


### PR DESCRIPTION
This PR provides a Typescript declaration file (`.d.ts`) that allows the Typescript compiler to perform type checking when `intercept-stdout` is imported in a Typescript project. Without the declaration file, if someone uses Typescript's `import` statement, the following error is printed:
```
TSError: Unable to compile TypeScript:
tests/helpers.ts:18:28 - error TS7016:
Could not find a declaration file for module 'intercept-stdout'.
'node_modules/intercept-stdout/intercept-stdout.js' implicitly has an 'any' type.
  Try `npm install @types/intercept-stdout` if it exists or add a
  new declaration (.d.ts) file containing `declare module 'intercept-stdout';`

18 import intercept = require('intercept-stdout');
```